### PR TITLE
Create FitWithAdi multi-page experience and member workflow

### DIFF
--- a/wp-content/themes/fitwithadi/assets/css/main.css
+++ b/wp-content/themes/fitwithadi/assets/css/main.css
@@ -869,6 +869,404 @@ textarea {
     font-weight: 600;
 }
 
+.site-logo__image {
+    display: block;
+    width: 160px;
+    height: auto;
+}
+
+.hero--front {
+    padding-block: clamp(4rem, 9vw, 7rem);
+}
+
+.about--expanded {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(2rem, 6vw, 4rem);
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+    margin-top: 2rem;
+}
+
+.feature-card {
+    background: var(--color-surface);
+    border-radius: 20px;
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.feature-card p {
+    color: var(--color-muted);
+}
+
+.card-grid--alt {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card--link {
+    position: relative;
+    border-top: 4px solid rgba(242, 78, 134, 0.4);
+}
+
+.card--link:hover,
+.card--link:focus-within {
+    border-top-color: var(--color-primary);
+    transform: translateY(-4px);
+}
+
+.pillars {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.pillars__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+}
+
+.pillar {
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 22px;
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.pillar p {
+    color: var(--color-muted);
+}
+
+.cta--front {
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+
+.page-hero {
+    padding-block: clamp(4rem, 10vw, 6.5rem) clamp(3rem, 8vw, 5rem);
+    background: radial-gradient(circle at top left, rgba(242, 78, 134, 0.1), transparent 60%),
+        #fff;
+}
+
+.page-hero__inner {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.page-hero .lead {
+    max-width: 720px;
+    color: var(--color-muted);
+}
+
+.page-section {
+    padding-top: 0;
+}
+
+.content-section__header {
+    max-width: 760px;
+    margin: 0 auto 2.5rem;
+    text-align: center;
+}
+
+.content-section__header p {
+    color: var(--color-muted);
+}
+
+.content-section__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.8rem;
+}
+
+.content-card {
+    background: var(--color-surface);
+    border-radius: 22px;
+    padding: 1.9rem;
+    display: grid;
+    gap: 1.6rem;
+    box-shadow: var(--shadow-soft);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.content-card:hover,
+.content-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.45);
+}
+
+.content-card__body h3 {
+    margin-bottom: 0.5rem;
+}
+
+.content-card__body p {
+    color: var(--color-muted);
+}
+
+.content-card__meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+}
+
+.content-card__link {
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.content-section__cta {
+    margin-top: 2.5rem;
+    text-align: center;
+}
+
+.content-section__empty {
+    text-align: center;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 2.5rem;
+    border-radius: 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+.content-section__empty p {
+    color: var(--color-muted);
+    margin-bottom: 1.5rem;
+}
+
+.subscription-tiers {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.tier {
+    background: var(--color-surface);
+    border-radius: 26px;
+    padding: 2.4rem 2rem;
+    display: grid;
+    gap: 1.2rem;
+    box-shadow: var(--shadow-soft);
+    position: relative;
+}
+
+.tier ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.8rem;
+    color: var(--color-muted);
+}
+
+.tier__price {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--color-primary);
+}
+
+.tier__price span {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-muted);
+    margin-left: 0.4rem;
+}
+
+.tier--featured {
+    background: linear-gradient(180deg, rgba(242, 78, 134, 0.14) 0%, rgba(255, 255, 255, 0.95) 100%);
+    border: 2px solid rgba(242, 78, 134, 0.35);
+    transform: translateY(-8px);
+}
+
+.tier__flag {
+    position: absolute;
+    top: -14px;
+    right: 24px;
+    background: var(--color-primary);
+    color: #fff;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.benefits {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.benefits__intro p {
+    color: var(--color-muted);
+}
+
+.benefits__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.8rem;
+}
+
+.benefit {
+    background: var(--color-surface);
+    border-radius: 22px;
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.benefit p {
+    color: var(--color-muted);
+}
+
+.next-steps {
+    display: grid;
+    gap: 2.5rem;
+    align-items: center;
+}
+
+.next-steps__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.member-access__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(2rem, 6vw, 4rem);
+    align-items: start;
+}
+
+.member-access__info ul {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0;
+    display: grid;
+    gap: 0.9rem;
+    color: var(--color-muted);
+}
+
+.member-access__links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.member-access__form {
+    background: var(--color-surface);
+    border-radius: 28px;
+    padding: clamp(2rem, 6vw, 3rem);
+    box-shadow: var(--shadow-soft);
+}
+
+.notice {
+    border-radius: 22px;
+    padding: 1.8rem;
+    margin-bottom: 1.5rem;
+    display: grid;
+    gap: 0.8rem;
+}
+
+.notice--success {
+    background: rgba(55, 190, 120, 0.12);
+    border: 1px solid rgba(55, 190, 120, 0.35);
+}
+
+.notice--error {
+    background: rgba(242, 78, 134, 0.12);
+    border: 1px solid rgba(242, 78, 134, 0.35);
+}
+
+.notice ul {
+    margin: 0;
+    padding-left: 1.2rem;
+}
+
+.member-form__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+}
+
+.member-form__group--full {
+    grid-column: 1 / -1;
+}
+
+.member-form__actions {
+    margin-top: 1.5rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.member-form__note {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+}
+
+.testimonials-page {
+    background: linear-gradient(180deg, rgba(242, 78, 134, 0.08) 0%, rgba(255, 255, 255, 0.9) 100%);
+}
+
+.testimonial-grid--full {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.testimonial--detailed {
+    background: var(--color-surface);
+    border-radius: 26px;
+    padding: clamp(2rem, 5vw, 3rem);
+    display: grid;
+    gap: 1.8rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.testimonial--detailed h2 {
+    margin-bottom: 0.5rem;
+}
+
+.testimonial__text p {
+    color: var(--color-muted);
+}
+
+.testimonial__media img {
+    width: 100%;
+    height: auto;
+    border-radius: 20px;
+}
+
+.testimonial__summary {
+    font-style: italic;
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.testimonial-empty {
+    text-align: center;
+    background: var(--color-surface);
+    border-radius: 26px;
+    padding: 3rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.testimonial-empty p {
+    color: var(--color-muted);
+    margin-bottom: 1.6rem;
+}
+
+.testimonials-cta__inner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.8rem;
+    align-items: center;
+}
+
+.testimonials-cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
 @media (max-width: 900px) {
     .nav-toggle {
         display: inline-flex;

--- a/wp-content/themes/fitwithadi/assets/css/main.css
+++ b/wp-content/themes/fitwithadi/assets/css/main.css
@@ -403,32 +403,34 @@ img {
     letter-spacing: 0.08em;
     text-transform: uppercase;
     box-shadow: var(--shadow-soft);
+    z-index: 2;
 }
 
 .hero__shape {
     position: absolute;
     border-radius: 40px;
     filter: drop-shadow(0 15px 35px rgba(15, 23, 42, 0.25));
+    z-index: 1;
 }
 
 .hero__shape--one {
-    inset: 15% 25% auto auto;
+    inset: auto -8% 4% auto;
     width: 220px;
     height: 320px;
     background: linear-gradient(180deg, rgba(242, 78, 134, 0.75), rgba(47, 123, 246, 0.75));
 }
 
 .hero__shape--two {
-    bottom: 12%;
-    left: 8%;
+    bottom: -10%;
+    left: 20%;
     width: 180px;
     height: 220px;
     background: linear-gradient(135deg, rgba(47, 123, 246, 0.75), rgba(255, 198, 234, 0.9));
 }
 
 .hero__shape--three {
-    top: 55%;
-    left: 35%;
+    top: 6%;
+    left: -6%;
     width: 120px;
     height: 120px;
     background: rgba(255, 198, 234, 0.9);

--- a/wp-content/themes/fitwithadi/assets/img/logo.svg
+++ b/wp-content/themes/fitwithadi/assets/img/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 72" role="img" aria-labelledby="fitwithadi-logo-title">
+  <title id="fitwithadi-logo-title">Fit With Adi</title>
+  <defs>
+    <linearGradient id="fitwithadiGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f24e86" />
+      <stop offset="100%" stop-color="#d63b6f" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="8" width="64" height="56" rx="18" fill="url(#fitwithadiGradient)" />
+  <path d="M28.6 44.6c2.8 0 4.9-1.7 4.9-4.3 0-2.2-1.5-3.5-4.1-4l-4.5-.8c-4.8-.9-7.4-3.7-7.4-7.9 0-5.4 4.3-9.2 10.4-9.2 4.6 0 8.3 2 9.9 5.4l-6.1 2.5c-.8-1.6-2-2.4-3.9-2.4-2.2 0-3.6 1.2-3.6 3 0 1.6 1 2.5 3.3 3l4.1.8c5.4 1 8.4 4 8.4 8.7 0 5.9-4.6 9.8-11.3 9.8-5.2 0-9.2-2.3-11.1-6.2l6.4-2.4c.8 2.1 2.3 3.4 4.6 3.4z" fill="#fff" />
+  <g fill="#1a1d29">
+    <text x="88" y="36" font-family="'Playfair Display', 'Georgia', serif" font-size="30" font-weight="700">Fit</text>
+    <text x="140" y="36" font-family="'Barlow', 'Helvetica Neue', sans-serif" font-size="18" font-weight="600" letter-spacing="0.2em">WITH</text>
+    <text x="88" y="58" font-family="'Playfair Display', 'Georgia', serif" font-size="30" font-weight="700">Adi</text>
+  </g>
+</svg>

--- a/wp-content/themes/fitwithadi/footer.php
+++ b/wp-content/themes/fitwithadi/footer.php
@@ -1,8 +1,8 @@
 <footer class="site-footer">
     <div class="container site-footer__inner">
         <div class="site-footer__brand">
-            <a class="site-logo site-logo--footer" href="<?php echo esc_url( home_url( '/' ) ); ?>">
-                <span class="site-logo__accent">Fit</span> With Adi
+            <a class="site-logo site-logo--footer" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="<?php esc_attr_e( 'Fit With Adi home', 'fitwithadi' ); ?>">
+                <img class="site-logo__image" src="<?php echo esc_url( get_template_directory_uri() . '/assets/img/logo.svg' ); ?>" alt="<?php esc_attr_e( 'Fit With Adi', 'fitwithadi' ); ?>" width="150" height="48">
             </a>
             <p class="site-footer__tagline"><?php esc_html_e( 'Private and group training in-studio or in the comfort of your home.', 'fitwithadi' ); ?></p>
         </div>

--- a/wp-content/themes/fitwithadi/functions.php
+++ b/wp-content/themes/fitwithadi/functions.php
@@ -30,6 +30,29 @@ if ( ! function_exists( 'fitwithadi_setup' ) ) {
 }
 add_action( 'after_setup_theme', 'fitwithadi_setup' );
 
+if ( ! function_exists( 'fitwithadi_get_page_link' ) ) {
+    /**
+     * Safely retrieve a page permalink by its path.
+     *
+     * @param string $path Page path/slug.
+     *
+     * @return string
+     */
+    function fitwithadi_get_page_link( $path ) {
+        if ( empty( $path ) ) {
+            return '#';
+        }
+
+        $page = get_page_by_path( $path );
+
+        if ( $page ) {
+            return get_permalink( $page );
+        }
+
+        return '#';
+    }
+}
+
 /**
  * Enqueue scripts and styles.
  */
@@ -63,14 +86,126 @@ add_action( 'wp_enqueue_scripts', 'fitwithadi_scripts' );
  */
 function fitwithadi_fallback_menu() {
     echo '<ul class="site-nav__list">';
-    echo '<li><a href="#about">About</a></li>';
-    echo '<li><a href="#services">Training</a></li>';
-    echo '<li><a href="#experience">Experience</a></li>';
-
-    echo '<li><a href="#schedule">Schedule</a></li>';
-
-    echo '<li><a href="#testimonials">Success Stories</a></li>';
-    echo '<li><a href="#contact">Contact</a></li>';
+    echo '<li><a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html__( 'Home', 'fitwithadi' ) . '</a></li>';
+    echo '<li><a href="' . esc_url( fitwithadi_get_page_link( 'content-hub' ) ) . '">' . esc_html__( 'Content Hub', 'fitwithadi' ) . '</a></li>';
+    echo '<li><a href="' . esc_url( fitwithadi_get_page_link( 'subscriptions' ) ) . '">' . esc_html__( 'Subscriptions', 'fitwithadi' ) . '</a></li>';
+    echo '<li><a href="' . esc_url( fitwithadi_get_page_link( 'member-access' ) ) . '">' . esc_html__( 'Member Access', 'fitwithadi' ) . '</a></li>';
+    echo '<li><a href="' . esc_url( fitwithadi_get_page_link( 'testimonials' ) ) . '">' . esc_html__( 'Testimonials', 'fitwithadi' ) . '</a></li>';
     echo '</ul>';
+}
+
+/**
+ * Register custom post types used by the theme.
+ */
+function fitwithadi_register_content_types() {
+    $labels = array(
+        'name'                  => _x( 'Testimonials', 'Post type general name', 'fitwithadi' ),
+        'singular_name'         => _x( 'Testimonial', 'Post type singular name', 'fitwithadi' ),
+        'menu_name'             => _x( 'Testimonials', 'Admin Menu text', 'fitwithadi' ),
+        'name_admin_bar'        => _x( 'Testimonial', 'Add New on Toolbar', 'fitwithadi' ),
+        'add_new'               => __( 'Add New', 'fitwithadi' ),
+        'add_new_item'          => __( 'Add New Testimonial', 'fitwithadi' ),
+        'new_item'              => __( 'New Testimonial', 'fitwithadi' ),
+        'edit_item'             => __( 'Edit Testimonial', 'fitwithadi' ),
+        'view_item'             => __( 'View Testimonial', 'fitwithadi' ),
+        'all_items'             => __( 'All Testimonials', 'fitwithadi' ),
+        'search_items'          => __( 'Search Testimonials', 'fitwithadi' ),
+        'not_found'             => __( 'No testimonials found.', 'fitwithadi' ),
+        'not_found_in_trash'    => __( 'No testimonials found in Trash.', 'fitwithadi' ),
+        'featured_image'        => _x( 'Client Photo', 'Overrides the “Featured Image” phrase', 'fitwithadi' ),
+        'set_featured_image'    => _x( 'Set client photo', 'Overrides the “Set featured image” phrase', 'fitwithadi' ),
+        'remove_featured_image' => _x( 'Remove client photo', 'Overrides the “Remove featured image” phrase', 'fitwithadi' ),
+        'use_featured_image'    => _x( 'Use as client photo', 'Overrides the “Use as featured image” phrase', 'fitwithadi' ),
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'show_in_rest'       => true,
+        'menu_icon'          => 'dashicons-testimonial',
+        'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+        'rewrite'            => array( 'slug' => 'stories' ),
+        'has_archive'        => false,
+    );
+
+    register_post_type( 'fit_testimonial', $args );
+}
+add_action( 'init', 'fitwithadi_register_content_types' );
+
+/**
+ * Register a simple admin page to review members who completed the waiver.
+ */
+function fitwithadi_register_member_admin_page() {
+    add_menu_page(
+        __( 'FitWithAdi Members', 'fitwithadi' ),
+        __( 'FitWithAdi Members', 'fitwithadi' ),
+        'manage_options',
+        'fitwithadi-members',
+        'fitwithadi_render_member_admin_page',
+        'dashicons-groups',
+        58
+    );
+}
+add_action( 'admin_menu', 'fitwithadi_register_member_admin_page' );
+
+/**
+ * Render the members administration screen.
+ */
+function fitwithadi_render_member_admin_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $members = get_users(
+        array(
+            'meta_key'     => 'fitwithadi_waiver_attachment_id',
+            'meta_compare' => 'EXISTS',
+            'orderby'      => 'registered',
+            'order'        => 'DESC',
+        )
+    );
+
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'FitWithAdi Member Directory', 'fitwithadi' ); ?></h1>
+        <p><?php esc_html_e( 'Review members who have completed the liability waiver. Click the waiver link to download the signed document.', 'fitwithadi' ); ?></p>
+        <?php if ( ! empty( $members ) ) : ?>
+            <table class="widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Member', 'fitwithadi' ); ?></th>
+                        <th><?php esc_html_e( 'Email', 'fitwithadi' ); ?></th>
+                        <th><?php esc_html_e( 'Registered', 'fitwithadi' ); ?></th>
+                        <th><?php esc_html_e( 'Waiver', 'fitwithadi' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php
+                    foreach ( $members as $member ) {
+                        $waiver_id  = get_user_meta( $member->ID, 'fitwithadi_waiver_attachment_id', true );
+                        $waiver_url = $waiver_id ? wp_get_attachment_url( $waiver_id ) : '';
+                        ?>
+                        <tr>
+                            <td><?php echo esc_html( $member->display_name ); ?></td>
+                            <td><a href="mailto:<?php echo esc_attr( $member->user_email ); ?>"><?php echo esc_html( $member->user_email ); ?></a></td>
+                            <td><?php echo esc_html( get_date_from_gmt( $member->user_registered, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ); ?></td>
+                            <td>
+                                <?php if ( $waiver_url ) : ?>
+                                    <a href="<?php echo esc_url( $waiver_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Download waiver', 'fitwithadi' ); ?></a>
+                                <?php else : ?>
+                                    <?php esc_html_e( 'Not uploaded', 'fitwithadi' ); ?>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <?php
+                    }
+                    ?>
+                </tbody>
+            </table>
+        <?php else : ?>
+            <p><?php esc_html_e( 'No members have submitted a waiver yet.', 'fitwithadi' ); ?></p>
+        <?php endif; ?>
+    </div>
+    <?php
 }
 

--- a/wp-content/themes/fitwithadi/header.php
+++ b/wp-content/themes/fitwithadi/header.php
@@ -10,8 +10,8 @@
 <a class="skip-link" href="#main-content"><?php esc_html_e( 'Skip to content', 'fitwithadi' ); ?></a>
 <header class="site-header" id="top">
     <div class="site-header__inner container">
-        <a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>">
-            <span class="site-logo__accent">Fit</span> With Adi
+        <a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="<?php esc_attr_e( 'Fit With Adi home', 'fitwithadi' ); ?>">
+            <img class="site-logo__image" src="<?php echo esc_url( get_template_directory_uri() . '/assets/img/logo.svg' ); ?>" alt="<?php esc_attr_e( 'Fit With Adi', 'fitwithadi' ); ?>" width="160" height="48">
         </a>
         <button class="nav-toggle" aria-controls="primary-navigation" aria-expanded="false">
             <span class="nav-toggle__label"><?php esc_html_e( 'Menu', 'fitwithadi' ); ?></span>
@@ -29,7 +29,10 @@
             );
             ?>
             <div class="site-nav__cta">
-                <a class="btn btn--small" href="#contact"><?php esc_html_e( 'Book a Session', 'fitwithadi' ); ?></a>
+                <?php
+                $member_access_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'member-access' ) : '#';
+                ?>
+                <a class="btn btn--small" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Join FitWithAdi', 'fitwithadi' ); ?></a>
             </div>
         </nav>
     </div>

--- a/wp-content/themes/fitwithadi/page-content-hub.php
+++ b/wp-content/themes/fitwithadi/page-content-hub.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Template for the Content Hub page.
+ *
+ * @package FitWithAdi
+ */
+
+global $post;
+
+get_header();
+?>
+<main id="main-content" class="site-main site-main--page">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <section class="page-hero">
+                <div class="container page-hero__inner">
+                    <h1><?php the_title(); ?></h1>
+                    <p class="lead">
+                        <?php
+                        if ( has_excerpt() ) {
+                            echo esc_html( get_the_excerpt() );
+                        } else {
+                            esc_html_e( 'Organize your workouts, challenges, and coaching resources so members always know what to train next.', 'fitwithadi' );
+                        }
+                        ?>
+                    </p>
+                </div>
+            </section>
+
+            <?php if ( '' !== get_the_content() ) : ?>
+                <section class="section section--light page-section">
+                    <div class="container">
+                        <?php the_content(); ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
+    <?php endif; ?>
+
+    <?php
+    $sections = array(
+        array(
+            'slug'        => 'videos',
+            'title'       => __( 'On-demand video library', 'fitwithadi' ),
+            'description' => __( 'Upload follow-along strength sessions, mobility resets, and technique breakdowns. Embed your video links directly in the post content so members can train from anywhere.', 'fitwithadi' ),
+            'empty'       => __( 'Add your first video post and tag it with the “videos” category to populate this section.', 'fitwithadi' ),
+        ),
+        array(
+            'slug'        => 'daily-challenges',
+            'title'       => __( 'Daily challenge vault', 'fitwithadi' ),
+            'description' => __( 'Keep momentum high with quick wins—post micro workouts, mindset prompts, or habit stacks that members can tackle in 15 minutes or less.', 'fitwithadi' ),
+            'empty'       => __( 'Share a new challenge and assign it to the “daily-challenges” category to feature it here.', 'fitwithadi' ),
+        ),
+        array(
+            'slug'        => 'weekly-plans',
+            'title'       => __( 'Weekly training plans', 'fitwithadi' ),
+            'description' => __( 'Map out the workouts, recovery sessions, and accountability touchpoints for each week. Attach PDFs or Google Drive links directly in the post body.', 'fitwithadi' ),
+            'empty'       => __( 'Publish your first plan and mark it with the “weekly-plans” category to display it for members.', 'fitwithadi' ),
+        ),
+    );
+
+    foreach ( $sections as $section ) :
+        $category = get_category_by_slug( $section['slug'] );
+        $query    = null;
+
+        if ( $category && ! is_wp_error( $category ) ) {
+            $query = new WP_Query(
+                array(
+                    'cat'            => $category->term_id,
+                    'posts_per_page' => 6,
+                    'post_status'    => 'publish',
+                )
+            );
+        }
+        ?>
+        <section class="section content-section" id="<?php echo esc_attr( $section['slug'] ); ?>">
+            <div class="container">
+                <div class="content-section__header">
+                    <h2><?php echo esc_html( $section['title'] ); ?></h2>
+                    <p><?php echo esc_html( $section['description'] ); ?></p>
+                </div>
+
+                <?php if ( $query instanceof WP_Query && $query->have_posts() ) : ?>
+                    <div class="content-section__grid">
+                        <?php
+                        while ( $query->have_posts() ) :
+                            $query->the_post();
+                            ?>
+                            <article class="content-card">
+                                <div class="content-card__body">
+                                    <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+                                    <p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 24 ) ); ?></p>
+                                </div>
+                                <div class="content-card__meta">
+                                    <span><?php echo esc_html( get_the_date() ); ?></span>
+                                    <a class="content-card__link" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View resource', 'fitwithadi' ); ?></a>
+                                </div>
+                            </article>
+                            <?php
+                        endwhile;
+                        ?>
+                    </div>
+                    <div class="content-section__cta">
+                        <a class="btn btn--outline" href="<?php echo esc_url( get_category_link( $category ) ); ?>"><?php esc_html_e( 'Browse all posts in this collection', 'fitwithadi' ); ?></a>
+                    </div>
+                    <?php wp_reset_postdata(); ?>
+                <?php else : ?>
+                    <div class="content-section__empty">
+                        <p><?php echo esc_html( $section['empty'] ); ?></p>
+                        <a class="btn btn--light" href="<?php echo esc_url( admin_url( 'post-new.php' ) ); ?>"><?php esc_html_e( 'Create a new post', 'fitwithadi' ); ?></a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </section>
+        <?php
+    endforeach;
+    ?>
+</main>
+<?php
+get_footer();

--- a/wp-content/themes/fitwithadi/page-member-access.php
+++ b/wp-content/themes/fitwithadi/page-member-access.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Template for the Member Access page with registration + waiver upload.
+ *
+ * @package FitWithAdi
+ */
+
+$registration_errors  = array();
+$registration_success = false;
+$form_values          = array(
+    'first_name' => '',
+    'last_name'  => '',
+    'email'      => '',
+    'goals'      => '',
+);
+
+if ( ! is_user_logged_in() && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+    $nonce = isset( $_POST['fitwithadi_member_register_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['fitwithadi_member_register_nonce'] ) ) : '';
+
+    if ( ! wp_verify_nonce( $nonce, 'fitwithadi_member_register' ) ) {
+        $registration_errors[] = __( 'Your session expired. Please refresh the page and try again.', 'fitwithadi' );
+    } else {
+        $form_values['first_name'] = isset( $_POST['first_name'] ) ? sanitize_text_field( wp_unslash( $_POST['first_name'] ) ) : '';
+        $form_values['last_name']  = isset( $_POST['last_name'] ) ? sanitize_text_field( wp_unslash( $_POST['last_name'] ) ) : '';
+        $form_values['email']      = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+        $password                  = isset( $_POST['password'] ) ? (string) $_POST['password'] : '';
+        $confirm_password          = isset( $_POST['confirm_password'] ) ? (string) $_POST['confirm_password'] : '';
+        $form_values['goals']      = isset( $_POST['goals'] ) ? sanitize_textarea_field( wp_unslash( $_POST['goals'] ) ) : '';
+
+        if ( '' === $form_values['first_name'] || '' === $form_values['last_name'] ) {
+            $registration_errors[] = __( 'Please share your first and last name.', 'fitwithadi' );
+        }
+
+        if ( '' === $form_values['email'] || ! is_email( $form_values['email'] ) ) {
+            $registration_errors[] = __( 'Enter a valid email address.', 'fitwithadi' );
+        } elseif ( email_exists( $form_values['email'] ) ) {
+            $registration_errors[] = __( 'An account with this email already exists. Try logging in or resetting your password.', 'fitwithadi' );
+        }
+
+        if ( strlen( $password ) < 8 ) {
+            $registration_errors[] = __( 'Choose a password that is at least eight characters long.', 'fitwithadi' );
+        }
+
+        if ( $password !== $confirm_password ) {
+            $registration_errors[] = __( 'Your password confirmation does not match.', 'fitwithadi' );
+        }
+
+        if ( empty( $_FILES['waiver']['name'] ) ) {
+            $registration_errors[] = __( 'Please upload your signed waiver as a PDF or image file.', 'fitwithadi' );
+        }
+
+        $waiver_attachment_id = 0;
+
+        if ( empty( $registration_errors ) ) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+
+            $uploaded_file = wp_handle_upload(
+                $_FILES['waiver'],
+                array(
+                    'test_form' => false,
+                )
+            );
+
+            if ( isset( $uploaded_file['error'] ) ) {
+                $registration_errors[] = $uploaded_file['error'];
+            } else {
+                $file_type = wp_check_filetype( basename( $uploaded_file['file'] ), null );
+                $allowed   = array( 'application/pdf', 'image/jpeg', 'image/png' );
+
+                if ( ! in_array( $file_type['type'], $allowed, true ) ) {
+                    $registration_errors[] = __( 'The waiver must be a PDF, JPG, or PNG file.', 'fitwithadi' );
+                    if ( file_exists( $uploaded_file['file'] ) ) {
+                        unlink( $uploaded_file['file'] );
+                    }
+                } else {
+                    require_once ABSPATH . 'wp-admin/includes/image.php';
+
+                    $attachment = array(
+                        'guid'           => $uploaded_file['url'],
+                        'post_mime_type' => $file_type['type'],
+                        'post_title'     => sprintf( __( '%1$s %2$s Waiver', 'fitwithadi' ), $form_values['first_name'], $form_values['last_name'] ),
+                        'post_content'   => '',
+                        'post_status'    => 'inherit',
+                    );
+
+                    $waiver_attachment_id = wp_insert_attachment( $attachment, $uploaded_file['file'] );
+
+                    if ( is_wp_error( $waiver_attachment_id ) ) {
+                        $registration_errors[] = __( 'We could not save your waiver. Please try again.', 'fitwithadi' );
+                        if ( file_exists( $uploaded_file['file'] ) ) {
+                            unlink( $uploaded_file['file'] );
+                        }
+                    } else {
+                        $attach_data = wp_generate_attachment_metadata( $waiver_attachment_id, $uploaded_file['file'] );
+                        wp_update_attachment_metadata( $waiver_attachment_id, $attach_data );
+                    }
+                }
+            }
+        }
+
+        if ( empty( $registration_errors ) ) {
+            $base_username = sanitize_user( current( explode( '@', $form_values['email'] ) ), true );
+
+            if ( '' === $base_username ) {
+                $base_username = 'fitmember';
+            }
+
+            $username = $base_username;
+            $suffix   = 1;
+
+            while ( username_exists( $username ) ) {
+                $username = $base_username . $suffix;
+                $suffix  += 1;
+            }
+
+            $user_id = wp_insert_user(
+                array(
+                    'user_login'   => $username,
+                    'user_pass'    => $password,
+                    'user_email'   => $form_values['email'],
+                    'first_name'   => $form_values['first_name'],
+                    'last_name'    => $form_values['last_name'],
+                    'display_name' => trim( $form_values['first_name'] . ' ' . $form_values['last_name'] ),
+                    'role'         => 'subscriber',
+                )
+            );
+
+            if ( is_wp_error( $user_id ) ) {
+                $registration_errors[] = $user_id->get_error_message();
+
+                if ( $waiver_attachment_id ) {
+                    wp_delete_attachment( $waiver_attachment_id, true );
+                }
+            } else {
+                update_user_meta( $user_id, 'fitwithadi_fitness_goals', $form_values['goals'] );
+
+                if ( $waiver_attachment_id ) {
+                    update_user_meta( $user_id, 'fitwithadi_waiver_attachment_id', $waiver_attachment_id );
+                }
+
+                if ( function_exists( 'wp_new_user_notification' ) ) {
+                    wp_new_user_notification( $user_id, null, 'both' );
+                }
+
+                $registration_success = true;
+                $form_values          = array(
+                    'first_name' => '',
+                    'last_name'  => '',
+                    'email'      => '',
+                    'goals'      => '',
+                );
+            }
+        }
+    }
+}
+
+$content_hub_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'content-hub' ) : '#';
+$subscriptions_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'subscriptions' ) : '#';
+$testimonials_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'testimonials' ) : '#';
+
+get_header();
+?>
+<main id="main-content" class="site-main site-main--page">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <section class="page-hero">
+                <div class="container page-hero__inner">
+                    <h1><?php the_title(); ?></h1>
+                    <p class="lead">
+                        <?php
+                        if ( has_excerpt() ) {
+                            echo esc_html( get_the_excerpt() );
+                        } else {
+                            esc_html_e( 'Create your FitWithAdi login, sign the waiver, and unlock every training resource.', 'fitwithadi' );
+                        }
+                        ?>
+                    </p>
+                </div>
+            </section>
+
+            <?php if ( '' !== get_the_content() ) : ?>
+                <section class="section section--light page-section">
+                    <div class="container">
+                        <?php the_content(); ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
+    <?php endif; ?>
+
+    <section class="section member-access">
+        <div class="container member-access__grid">
+            <div class="member-access__info">
+                <h2><?php esc_html_e( 'What you get with your account', 'fitwithadi' ); ?></h2>
+                <ul>
+                    <li><?php esc_html_e( 'Instant access to the content hub with videos, challenges, and weekly plans.', 'fitwithadi' ); ?></li>
+                    <li><?php esc_html_e( 'Ability to join subscriptions, enroll in challenges, and track your progress.', 'fitwithadi' ); ?></li>
+                    <li><?php esc_html_e( 'Direct communication from Adi for accountability and program updates.', 'fitwithadi' ); ?></li>
+                </ul>
+                <div class="member-access__links">
+                    <a class="btn btn--outline" href="<?php echo esc_url( $subscriptions_link ); ?>"><?php esc_html_e( 'View membership options', 'fitwithadi' ); ?></a>
+                    <a class="btn btn--light" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'Preview the content hub', 'fitwithadi' ); ?></a>
+                    <a class="btn btn--light" href="<?php echo esc_url( $testimonials_link ); ?>"><?php esc_html_e( 'Read member stories', 'fitwithadi' ); ?></a>
+                </div>
+            </div>
+            <div class="member-access__form">
+                <?php if ( is_user_logged_in() ) : ?>
+                    <div class="notice notice--success">
+                        <h2><?php esc_html_e( 'You’re already logged in!', 'fitwithadi' ); ?></h2>
+                        <p><?php esc_html_e( 'Head to the content hub to start your next session.', 'fitwithadi' ); ?></p>
+                        <a class="btn" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'Go to the content hub', 'fitwithadi' ); ?></a>
+                    </div>
+                <?php else : ?>
+                    <?php if ( $registration_success ) : ?>
+                        <div class="notice notice--success">
+                            <h2><?php esc_html_e( 'Account created!', 'fitwithadi' ); ?></h2>
+                            <p><?php esc_html_e( 'Check your email for login details and next steps from Adi. You can now log in and access all member resources.', 'fitwithadi' ); ?></p>
+                        </div>
+                    <?php else : ?>
+                        <?php if ( ! empty( $registration_errors ) ) : ?>
+                            <div class="notice notice--error">
+                                <h2><?php esc_html_e( 'We need a quick fix.', 'fitwithadi' ); ?></h2>
+                                <ul>
+                                    <?php foreach ( $registration_errors as $error ) : ?>
+                                        <li><?php echo esc_html( $error ); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <form class="member-form" method="post" enctype="multipart/form-data">
+                            <?php wp_nonce_field( 'fitwithadi_member_register', 'fitwithadi_member_register_nonce' ); ?>
+                            <div class="member-form__grid">
+                                <div class="member-form__group">
+                                    <label for="member-first-name"><?php esc_html_e( 'First name', 'fitwithadi' ); ?></label>
+                                    <input type="text" id="member-first-name" name="first_name" value="<?php echo esc_attr( $form_values['first_name'] ); ?>" required>
+                                </div>
+                                <div class="member-form__group">
+                                    <label for="member-last-name"><?php esc_html_e( 'Last name', 'fitwithadi' ); ?></label>
+                                    <input type="text" id="member-last-name" name="last_name" value="<?php echo esc_attr( $form_values['last_name'] ); ?>" required>
+                                </div>
+                                <div class="member-form__group member-form__group--full">
+                                    <label for="member-email"><?php esc_html_e( 'Email address', 'fitwithadi' ); ?></label>
+                                    <input type="email" id="member-email" name="email" value="<?php echo esc_attr( $form_values['email'] ); ?>" required>
+                                </div>
+                                <div class="member-form__group">
+                                    <label for="member-password"><?php esc_html_e( 'Create password', 'fitwithadi' ); ?></label>
+                                    <input type="password" id="member-password" name="password" minlength="8" required>
+                                </div>
+                                <div class="member-form__group">
+                                    <label for="member-password-confirm"><?php esc_html_e( 'Confirm password', 'fitwithadi' ); ?></label>
+                                    <input type="password" id="member-password-confirm" name="confirm_password" minlength="8" required>
+                                </div>
+                                <div class="member-form__group member-form__group--full">
+                                    <label for="member-goals"><?php esc_html_e( 'Share your goals + any injuries', 'fitwithadi' ); ?></label>
+                                    <textarea id="member-goals" name="goals" rows="4"><?php echo esc_textarea( $form_values['goals'] ); ?></textarea>
+                                </div>
+                                <div class="member-form__group member-form__group--full">
+                                    <label for="member-waiver"><?php esc_html_e( 'Upload signed waiver (PDF, JPG, or PNG)', 'fitwithadi' ); ?></label>
+                                    <input type="file" id="member-waiver" name="waiver" accept=".pdf,.jpg,.jpeg,.png" required>
+                                </div>
+                            </div>
+                            <div class="member-form__actions">
+                                <button type="submit" class="btn btn--dark"><?php esc_html_e( 'Create my account', 'fitwithadi' ); ?></button>
+                                <p class="member-form__note"><?php esc_html_e( 'By submitting you agree to the FitWithAdi terms, privacy policy, and community guidelines.', 'fitwithadi' ); ?></p>
+                            </div>
+                        </form>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </section>
+</main>
+<?php
+get_footer();

--- a/wp-content/themes/fitwithadi/page-subscriptions.php
+++ b/wp-content/themes/fitwithadi/page-subscriptions.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Template for the Subscriptions page.
+ *
+ * @package FitWithAdi
+ */
+
+$content_hub_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'content-hub' ) : '#';
+$member_access_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'member-access' ) : '#';
+$testimonials_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'testimonials' ) : '#';
+
+global $post;
+
+get_header();
+?>
+<main id="main-content" class="site-main site-main--page">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <section class="page-hero">
+                <div class="container page-hero__inner">
+                    <h1><?php the_title(); ?></h1>
+                    <p class="lead">
+                        <?php
+                        if ( has_excerpt() ) {
+                            echo esc_html( get_the_excerpt() );
+                        } else {
+                            esc_html_e( 'Choose the training experience that fits your lifestyle and unlock every resource inside FitWithAdi.', 'fitwithadi' );
+                        }
+                        ?>
+                    </p>
+                </div>
+            </section>
+
+            <?php if ( '' !== get_the_content() ) : ?>
+                <section class="section section--light page-section">
+                    <div class="container">
+                        <?php the_content(); ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
+    <?php endif; ?>
+
+    <section class="section section--light" id="tiers">
+        <div class="container">
+            <div class="section__heading">
+                <h2><?php esc_html_e( 'Memberships designed for every season', 'fitwithadi' ); ?></h2>
+                <p><?php esc_html_e( 'Each plan includes access to the content hub, accountability check-ins, and an invite to our private community.', 'fitwithadi' ); ?></p>
+            </div>
+            <div class="subscription-tiers">
+                <article class="tier">
+                    <h3><?php esc_html_e( 'Momentum Starter', 'fitwithadi' ); ?></h3>
+                    <p class="tier__price">$59<span><?php esc_html_e( '/month', 'fitwithadi' ); ?></span></p>
+                    <ul>
+                        <li><?php esc_html_e( 'Weekly training plan + video playlist', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Two live group workouts per month', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Progress tracking dashboard', 'fitwithadi' ); ?></li>
+                    </ul>
+                    <a class="btn btn--outline tier__cta" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Start your trial', 'fitwithadi' ); ?></a>
+                </article>
+                <article class="tier tier--featured">
+                    <div class="tier__flag"><?php esc_html_e( 'Most popular', 'fitwithadi' ); ?></div>
+                    <h3><?php esc_html_e( 'Limitless Coaching', 'fitwithadi' ); ?></h3>
+                    <p class="tier__price">$149<span><?php esc_html_e( '/month', 'fitwithadi' ); ?></span></p>
+                    <ul>
+                        <li><?php esc_html_e( 'Weekly 1:1 check-in with Adi', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Unlimited content hub access', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Monthly custom program adjustments', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Priority registration for challenges & events', 'fitwithadi' ); ?></li>
+                    </ul>
+                    <a class="btn tier__cta" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Join Limitless', 'fitwithadi' ); ?></a>
+                </article>
+                <article class="tier">
+                    <h3><?php esc_html_e( 'Elite VIP', 'fitwithadi' ); ?></h3>
+                    <p class="tier__price">$349<span><?php esc_html_e( '/month', 'fitwithadi' ); ?></span></p>
+                    <ul>
+                        <li><?php esc_html_e( 'Weekly private sessions (in-person or virtual)', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Personalized nutrition check-ins', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Quarterly in-person retreats & labs', 'fitwithadi' ); ?></li>
+                        <li><?php esc_html_e( 'Direct message support Monday–Friday', 'fitwithadi' ); ?></li>
+                    </ul>
+                    <a class="btn btn--outline tier__cta" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Apply for VIP', 'fitwithadi' ); ?></a>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section class="section" id="benefits">
+        <div class="container benefits">
+            <div class="benefits__intro">
+                <h2><?php esc_html_e( 'Every membership includes', 'fitwithadi' ); ?></h2>
+                <p><?php esc_html_e( 'Members get coaching systems that make consistency easy—plus the community vibes that keep you coming back.', 'fitwithadi' ); ?></p>
+            </div>
+            <div class="benefits__grid">
+                <article class="benefit">
+                    <h3><?php esc_html_e( 'Training calendars synced to your life', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Swap workouts, add rest days, and mark progress directly inside the content hub.', 'fitwithadi' ); ?></p>
+                </article>
+                <article class="benefit">
+                    <h3><?php esc_html_e( 'Live + on-demand experiences', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Mix energetic group sessions with structured home workouts so you’re never without a plan.', 'fitwithadi' ); ?></p>
+                </article>
+                <article class="benefit">
+                    <h3><?php esc_html_e( 'Accountability from Adi', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Direct support through check-ins, milestone celebrations, and strategy tweaks when life gets busy.', 'fitwithadi' ); ?></p>
+                </article>
+                <article class="benefit">
+                    <h3><?php esc_html_e( 'Community celebrations', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Spotlight members, share testimonials, and highlight wins straight from the FitWithAdi fam.', 'fitwithadi' ); ?></p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section--light" id="next-steps">
+        <div class="container next-steps">
+            <div class="next-steps__content">
+                <h2><?php esc_html_e( 'Next steps', 'fitwithadi' ); ?></h2>
+                <ol>
+                    <li><?php esc_html_e( 'Create your member profile and sign the waiver.', 'fitwithadi' ); ?></li>
+                    <li><?php esc_html_e( 'Choose the subscription that matches your goals.', 'fitwithadi' ); ?></li>
+                    <li><?php esc_html_e( 'Dive into the content hub and join our next challenge.', 'fitwithadi' ); ?></li>
+                </ol>
+            </div>
+            <div class="next-steps__actions">
+                <a class="btn" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Get started', 'fitwithadi' ); ?></a>
+                <a class="btn btn--outline" href="<?php echo esc_url( $testimonials_link ); ?>"><?php esc_html_e( 'Read member success stories', 'fitwithadi' ); ?></a>
+                <a class="btn btn--light" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'Preview the content library', 'fitwithadi' ); ?></a>
+            </div>
+        </div>
+    </section>
+</main>
+<?php
+get_footer();

--- a/wp-content/themes/fitwithadi/page-testimonials.php
+++ b/wp-content/themes/fitwithadi/page-testimonials.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Template for the Testimonials page.
+ *
+ * @package FitWithAdi
+ */
+
+$content_hub_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'content-hub' ) : '#';
+$subscriptions_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'subscriptions' ) : '#';
+$member_access_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'member-access' ) : '#';
+
+global $post;
+
+get_header();
+?>
+<main id="main-content" class="site-main site-main--page">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <section class="page-hero">
+                <div class="container page-hero__inner">
+                    <h1><?php the_title(); ?></h1>
+                    <p class="lead">
+                        <?php
+                        if ( has_excerpt() ) {
+                            echo esc_html( get_the_excerpt() );
+                        } else {
+                            esc_html_e( 'Celebrate transformation stories from the FitWithAdi community.', 'fitwithadi' );
+                        }
+                        ?>
+                    </p>
+                </div>
+            </section>
+
+            <?php if ( '' !== get_the_content() ) : ?>
+                <section class="section section--light page-section">
+                    <div class="container">
+                        <?php the_content(); ?>
+                    </div>
+                </section>
+            <?php endif; ?>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
+    <?php endif; ?>
+
+    <?php
+    $testimonials = new WP_Query(
+        array(
+            'post_type'      => 'fit_testimonial',
+            'posts_per_page' => -1,
+            'post_status'    => 'publish',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+        )
+    );
+    ?>
+
+    <section class="section testimonials-page">
+        <div class="container">
+            <?php if ( $testimonials->have_posts() ) : ?>
+                <div class="testimonial-grid testimonial-grid--full">
+                    <?php
+                    while ( $testimonials->have_posts() ) :
+                        $testimonials->the_post();
+                        ?>
+                        <article class="testimonial testimonial--detailed">
+                            <div class="testimonial__content">
+                                <h2><?php the_title(); ?></h2>
+                                <div class="testimonial__text">
+                                    <?php the_content(); ?>
+                                </div>
+                                <?php if ( has_excerpt() ) : ?>
+                                    <p class="testimonial__summary">“<?php echo esc_html( get_the_excerpt() ); ?>”</p>
+                                <?php endif; ?>
+                            </div>
+                            <?php if ( has_post_thumbnail() ) : ?>
+                                <div class="testimonial__media">
+                                    <?php the_post_thumbnail( 'medium_large' ); ?>
+                                </div>
+                            <?php endif; ?>
+                        </article>
+                        <?php
+                    endwhile;
+                    ?>
+                </div>
+                <?php wp_reset_postdata(); ?>
+            <?php else : ?>
+                <div class="testimonial-empty">
+                    <h2><?php esc_html_e( 'Testimonials are on the way', 'fitwithadi' ); ?></h2>
+                    <p><?php esc_html_e( 'Share your clients’ stories by adding new Testimonial entries from the WordPress dashboard.', 'fitwithadi' ); ?></p>
+                    <a class="btn btn--outline" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=fit_testimonial' ) ); ?>"><?php esc_html_e( 'Add a testimonial', 'fitwithadi' ); ?></a>
+                </div>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section class="section section--light testimonials-cta">
+        <div class="container testimonials-cta__inner">
+            <div class="testimonials-cta__content">
+                <h2><?php esc_html_e( 'Ready to write your own story?', 'fitwithadi' ); ?></h2>
+                <p><?php esc_html_e( 'Join the FitWithAdi community, start training with Adi, and we’ll feature your wins next.', 'fitwithadi' ); ?></p>
+            </div>
+            <div class="testimonials-cta__actions">
+                <a class="btn" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Create your account', 'fitwithadi' ); ?></a>
+                <a class="btn btn--outline" href="<?php echo esc_url( $subscriptions_link ); ?>"><?php esc_html_e( 'Explore memberships', 'fitwithadi' ); ?></a>
+                <a class="btn btn--light" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'See the content library', 'fitwithadi' ); ?></a>
+            </div>
+        </div>
+    </section>
+</main>
+<?php
+get_footer();

--- a/wp-content/themes/fitwithadi/template-parts/content-home.php
+++ b/wp-content/themes/fitwithadi/template-parts/content-home.php
@@ -1,30 +1,46 @@
-<section class="hero" id="hero">
+<?php
+/**
+ * Front-page content template.
+ *
+ * @package FitWithAdi
+ */
+
+$content_hub_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'content-hub' ) : '#';
+$subscriptions_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'subscriptions' ) : '#';
+$member_access_link = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'member-access' ) : '#';
+$testimonials_link  = function_exists( 'fitwithadi_get_page_link' ) ? fitwithadi_get_page_link( 'testimonials' ) : '#';
+?>
+<section class="hero hero--front" id="hero">
     <div class="container hero__inner">
         <div class="hero__content">
-            <p class="eyebrow"><?php esc_html_e( 'Personal Training · Small Group Coaching · Wellness Lifestyle', 'fitwithadi' ); ?></p>
-            <h1><?php esc_html_e( 'Strong looks good on you.', 'fitwithadi' ); ?></h1>
-            <p class="lead"><?php esc_html_e( 'Adi designs personalized, confidence-building workouts for women in Los Angeles—delivered in her boutique studio, your home gym, or energized group sessions that feel like a celebration.', 'fitwithadi' ); ?></p>
+            <p class="eyebrow"><?php esc_html_e( 'Founder · Coach · Community Builder', 'fitwithadi' ); ?></p>
+            <h1><?php esc_html_e( 'Welcome to FitWithAdi.com', 'fitwithadi' ); ?></h1>
+            <p class="lead">
+                <?php
+                esc_html_e( 'I’m Adi—your coach, hype woman, and accountability partner. This is where we blend strength, sweat, and sisterhood to help you feel unstoppable in every season of life.', 'fitwithadi' );
+                ?>
+            </p>
             <div class="hero__actions">
-                <a class="btn" href="#contact"><?php esc_html_e( 'Book a Session', 'fitwithadi' ); ?></a>
-                <a class="btn btn--outline" href="#services"><?php esc_html_e( 'Explore Training Paths', 'fitwithadi' ); ?></a>
+                <a class="btn" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Create your account', 'fitwithadi' ); ?></a>
+                <a class="btn btn--outline" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'Preview the content hub', 'fitwithadi' ); ?></a>
             </div>
             <ul class="hero__highlights">
                 <li>
-                    <span class="hero__metric">12+</span>
-                    <span><?php esc_html_e( 'years coaching experience', 'fitwithadi' ); ?></span>
+                    <span class="hero__metric">100%</span>
+                    <span><?php esc_html_e( 'Personalized training experience', 'fitwithadi' ); ?></span>
                 </li>
                 <li>
-                    <span class="hero__metric">400+</span>
-                    <span><?php esc_html_e( 'clients empowered', 'fitwithadi' ); ?></span>
+                    <span class="hero__metric">5</span>
+                    <span><?php esc_html_e( 'Curated member-only spaces', 'fitwithadi' ); ?></span>
                 </li>
                 <li>
-                    <span class="hero__metric">3</span>
-                    <span><?php esc_html_e( 'flexible training formats', 'fitwithadi' ); ?></span>
+                    <span class="hero__metric">∞</span>
+                    <span><?php esc_html_e( 'Support, encouragement, & community', 'fitwithadi' ); ?></span>
                 </li>
             </ul>
         </div>
         <div class="hero__media" aria-hidden="true">
-            <div class="hero__badge">Adi · NASM CPT · Pre/Postnatal Specialist</div>
+            <div class="hero__badge">Adi · NASM CPT · Women’s Fitness Specialist</div>
             <div class="hero__shape hero__shape--one"></div>
             <div class="hero__shape hero__shape--two"></div>
             <div class="hero__shape hero__shape--three"></div>
@@ -33,289 +49,101 @@
 </section>
 
 <section class="section section--light" id="about">
-    <div class="container about">
+    <div class="container about about--expanded">
         <div class="about__image" aria-hidden="true"></div>
         <div class="about__content">
             <h2><?php esc_html_e( 'Meet Adi', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Fit With Adi is a space where women are seen, supported, and challenged with intention. Adi blends evidence-based strength training with mindful conditioning to meet you exactly where you are and move you toward where you want to go.', 'fitwithadi' ); ?></p>
-            <div class="about__grid">
-                <div class="about__item">
-                    <h3><?php esc_html_e( 'Personal studio sanctuary', 'fitwithadi' ); ?></h3>
-                    <p><?php esc_html_e( 'Train in a sunlit Venice studio equipped with everything from kettlebells to reformers—no intimidating crowds, just curated vibes.', 'fitwithadi' ); ?></p>
-                </div>
-                <div class="about__item">
-                    <h3><?php esc_html_e( 'In-home training made effortless', 'fitwithadi' ); ?></h3>
-                    <p><?php esc_html_e( 'Adi travels across Los Angeles with customized equipment kits, turning living rooms and home gyms into motivating training grounds.', 'fitwithadi' ); ?></p>
-                </div>
-                <div class="about__item">
-                    <h3><?php esc_html_e( 'Group energy that uplifts', 'fitwithadi' ); ?></h3>
-                    <p><?php esc_html_e( 'Small, high-touch classes capped at eight women keep the focus on form, connection, and serious results.', 'fitwithadi' ); ?></p>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-
-<section class="section" id="services">
-    <div class="container">
-        <div class="section__heading">
-            <h2><?php esc_html_e( 'Choose your coaching experience', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Every program begins with a movement assessment and lifestyle deep dive so we can craft your roadmap together.', 'fitwithadi' ); ?></p>
-        </div>
-        <div class="card-grid">
-            <article class="card">
-                <h3><?php esc_html_e( 'Private Studio Training', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'One-on-one sessions inside Adi’s airy Venice studio. Expect progressive strength blocks, mobility work, and nervous-system resets tailored to your goals.', 'fitwithadi' ); ?></p>
-                <ul>
-                    <li><?php esc_html_e( '60- or 90-minute sessions', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Body composition & performance tracking', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Recovery lounge with contrast therapy', 'fitwithadi' ); ?></li>
-                </ul>
-                <a class="card__link" href="#contact"><?php esc_html_e( 'Reserve your consultation', 'fitwithadi' ); ?></a>
-            </article>
-            <article class="card">
-                <h3><?php esc_html_e( 'In-Home & On-Location', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Prefer training where you live or work? Adi brings the equipment, curated playlists, and professional coaching to you—indoors or outdoors.', 'fitwithadi' ); ?></p>
-                <ul>
-                    <li><?php esc_html_e( 'Customized equipment setups', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Travel across Westside & South Bay', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Option to train with a partner', 'fitwithadi' ); ?></li>
-                </ul>
-                <a class="card__link" href="#contact"><?php esc_html_e( 'Plan an on-the-go session', 'fitwithadi' ); ?></a>
-            </article>
-            <article class="card">
-                <h3><?php esc_html_e( 'High-Energy Group Sessions', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Signature Fit With Adi classes blend strength circuits with athletic conditioning. Designed for all levels with layered progressions.', 'fitwithadi' ); ?></p>
-                <ul>
-                    <li><?php esc_html_e( 'Weekly small-group schedule', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Semi-private attention', 'fitwithadi' ); ?></li>
-                    <li><?php esc_html_e( 'Retreats & pop-up events', 'fitwithadi' ); ?></li>
-                </ul>
-                <a class="card__link" href="#group-training"><?php esc_html_e( 'View upcoming groups', 'fitwithadi' ); ?></a>
-            </article>
-        </div>
-    </div>
-</section>
-
-<section class="section section--accent" id="experience">
-    <div class="container experience">
-        <div class="experience__intro">
-            <h2><?php esc_html_e( 'The Fit With Adi experience', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'We mix science-backed programming with soul-nourishing support so your routine feels consistent, doable, and exciting.', 'fitwithadi' ); ?></p>
-        </div>
-        <div class="experience__steps">
-            <div class="step">
-                <span class="step__number">01</span>
-                <h3><?php esc_html_e( 'Connect & clarify', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Start with a complimentary consultation to map your goals, schedule, and training preferences.', 'fitwithadi' ); ?></p>
-            </div>
-            <div class="step">
-                <span class="step__number">02</span>
-                <h3><?php esc_html_e( 'Custom program build', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Adi designs your periodized plan with strength, conditioning, recovery, and accountability woven together.', 'fitwithadi' ); ?></p>
-            </div>
-            <div class="step">
-                <span class="step__number">03</span>
-                <h3><?php esc_html_e( 'Train, track, celebrate', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Weekly sessions, check-ins, and progress milestones keep you inspired. Every win is celebrated—big and small.', 'fitwithadi' ); ?></p>
-            </div>
-        </div>
-    </div>
-</section>
-
-<section class="section" id="group-training">
-    <div class="container group">
-        <div class="section__heading">
-            <h2><?php esc_html_e( 'Group training that feels personal', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Rotating themes keep classes fresh—think strength & stretch, power circuits, and outdoor sunrise sweat sessions.', 'fitwithadi' ); ?></p>
-        </div>
-        <div class="group__grid">
-            <div class="group__card">
-                <h3><?php esc_html_e( 'Monday · Sculpt & Strength', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Total-body session with tempo lifts, resistance bands, and glute finishers.', 'fitwithadi' ); ?></p>
-                <p class="group__time">6:30 AM & 6:00 PM</p>
-            </div>
-            <div class="group__card">
-                <h3><?php esc_html_e( 'Wednesday · Athletic Conditioning', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Ladder drills, kettlebell complexes, and partner core challenges for a playful burn.', 'fitwithadi' ); ?></p>
-                <p class="group__time">7:00 AM & 7:30 PM</p>
-            </div>
-            <div class="group__card">
-                <h3><?php esc_html_e( 'Saturday · Sunrise Sweat', 'fitwithadi' ); ?></h3>
-                <p><?php esc_html_e( 'Beachfront HIIT meets breathwork cool-down. Start the weekend with intention.', 'fitwithadi' ); ?></p>
-                <p class="group__time">8:00 AM · Venice Beach</p>
-            </div>
-        </div>
-        <div class="group__cta">
-            <p><?php esc_html_e( 'Traveling with a crew or planning a private event?', 'fitwithadi' ); ?></p>
-            <a class="btn btn--outline" href="#contact"><?php esc_html_e( 'Ask about custom group experiences', 'fitwithadi' ); ?></a>
-        </div>
-    </div>
-</section>
-
-<section class="section section--light" id="testimonials">
-    <div class="container">
-        <div class="section__heading">
-            <h2><?php esc_html_e( 'Client love & transformation', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Stories from women who trusted the process and built strength from the inside out.', 'fitwithadi' ); ?></p>
-        </div>
-        <div class="testimonial-grid">
-            <article class="testimonial">
-                <p class="testimonial__quote">“<?php esc_html_e( 'Adi made fitness feel joyful again. I lost 18 pounds, gained serious strength, and finally look forward to workouts.', 'fitwithadi' ); ?>”</p>
-                <p class="testimonial__author">— Maya, new mom & entrepreneur</p>
-            </article>
-            <article class="testimonial">
-                <p class="testimonial__quote">“<?php esc_html_e( 'Her in-home sessions fit seamlessly around my work travel. The accountability texts and mobility homework are game changers.', 'fitwithadi' ); ?>”</p>
-                <p class="testimonial__author">— Lauren, film producer</p>
-            </article>
-            <article class="testimonial">
-                <p class="testimonial__quote">“<?php esc_html_e( 'The group classes are the perfect blend of sweat and sisterhood. I found my community and a trainer who truly cares.', 'fitwithadi' ); ?>”</p>
-                <p class="testimonial__author">— Jess, community manager</p>
-            </article>
-        </div>
-    </div>
-</section>
-
-<section class="section" id="resources">
-    <div class="container resources">
-        <div class="resources__content">
-            <h2><?php esc_html_e( 'Wellness beyond the workout', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'From nourishing recipes to mobility resets, explore articles curated by Adi to keep you inspired between sessions.', 'fitwithadi' ); ?></p>
-            <a class="btn btn--light" href="#contact"><?php esc_html_e( 'Request the latest guide', 'fitwithadi' ); ?></a>
-        </div>
-        <div class="resources__list">
-            <?php
-            $recent_posts = new WP_Query(
-                array(
-                    'posts_per_page' => 3,
-                    'post_status'   => 'publish',
-                )
-            );
-            if ( $recent_posts->have_posts() ) :
-                while ( $recent_posts->have_posts() ) :
-                    $recent_posts->the_post();
-                    ?>
-                    <article class="resource">
-                        <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-                        <p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 18 ) ); ?></p>
-                        <a class="resource__link" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Read more', 'fitwithadi' ); ?></a>
-                    </article>
-                    <?php
-                endwhile;
-                wp_reset_postdata();
-            else :
+            <p>
+                <?php
+                esc_html_e( 'Strength changed my life, and now I help women rewrite their own stories with movement. From first-time lifters to lifelong athletes, I create training plans that celebrate progress, protect your body, and keep you coming back for more.', 'fitwithadi' );
                 ?>
-                <article class="resource resource--empty">
-                    <h3><?php esc_html_e( 'New resources launching soon', 'fitwithadi' ); ?></h3>
-                    <p><?php esc_html_e( 'Join the Fit With Adi newsletter to be the first to receive fresh workouts, playlists, and mindful rituals.', 'fitwithadi' ); ?></p>
+            </p>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3><?php esc_html_e( 'Personal attention', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Assessments, goal setting, and progressive programming tailored to the way you move and recover.', 'fitwithadi' ); ?></p>
                 </article>
-                <?php
-            endif;
-            ?>
+                <article class="feature-card">
+                    <h3><?php esc_html_e( 'Holistic coaching', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Strength, mobility, nutrition guidance, and mindset support—delivered with compassion and accountability.', 'fitwithadi' ); ?></p>
+                </article>
+                <article class="feature-card">
+                    <h3><?php esc_html_e( 'Community energy', 'fitwithadi' ); ?></h3>
+                    <p><?php esc_html_e( 'Whether we’re training 1:1 or in a group challenge, you’ll feel supported by a vibrant crew.', 'fitwithadi' ); ?></p>
+                </article>
+            </div>
         </div>
     </div>
 </section>
 
-
-<section class="section" id="schedule">
-    <div class="container schedule">
-        <div class="schedule__intro">
-            <h2><?php esc_html_e( 'Book your group session', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Browse the latest small-group offerings and lock in your spot. Adi will follow up personally with class details and how to prepare.', 'fitwithadi' ); ?></p>
-            <ul class="schedule__list">
-                <li><?php esc_html_e( 'Real-time availability for every upcoming group class', 'fitwithadi' ); ?></li>
-                <li><?php esc_html_e( 'Secure your preferred date and time instantly', 'fitwithadi' ); ?></li>
-                <li><?php esc_html_e( 'Automatic confirmations and session reminders', 'fitwithadi' ); ?></li>
-            </ul>
-            <a class="btn btn--dark" href="#contact"><?php esc_html_e( 'Looking for 1:1 training? Contact Adi directly', 'fitwithadi' ); ?></a>
+<section class="section" id="site-map">
+    <div class="container">
+        <div class="section__heading">
+            <h2><?php esc_html_e( 'Your FitWithAdi journey at a glance', 'fitwithadi' ); ?></h2>
+            <p><?php esc_html_e( 'Explore every page of the site to access personal coaching, fresh workouts, exclusive memberships, and community stories.', 'fitwithadi' ); ?></p>
         </div>
-        <div class="schedule__embed">
-            <?php
-            $booking_markup               = '';
-            $booking_shortcode_available = shortcode_exists( 'ssa_booking' );
-
-            if ( $booking_shortcode_available ) {
-                $booking_markup = do_shortcode( '[ssa_booking]' );
-            }
-
-            if ( trim( (string) $booking_markup ) !== '' ) :
-                echo $booking_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-            else :
-                ?>
-                <div class="schedule__fallback">
-                    <?php if ( ! $booking_shortcode_available ) : ?>
-                        <p><?php esc_html_e( 'Our live booking calendar will appear here once the Simply Schedule Appointments plugin is activated.', 'fitwithadi' ); ?></p>
-                    <?php else : ?>
-                        <p><?php esc_html_e( 'The booking calendar is temporarily unavailable. Contact Adi directly to reserve your preferred time.', 'fitwithadi' ); ?></p>
-                    <?php endif; ?>
-                    <a class="btn btn--outline" href="#contact"><?php esc_html_e( 'Contact Adi to reserve your time', 'fitwithadi' ); ?></a>
-                </div>
-                <?php
-            endif;
-            ?>
+        <div class="card-grid card-grid--alt">
+            <article class="card card--link">
+                <h3><?php esc_html_e( 'Content Hub', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Upload and organize on-demand videos, daily challenges, and weekly training plans for your clients.', 'fitwithadi' ); ?></p>
+                <a class="card__link" href="<?php echo esc_url( $content_hub_link ); ?>"><?php esc_html_e( 'Visit the hub', 'fitwithadi' ); ?></a>
+            </article>
+            <article class="card card--link">
+                <h3><?php esc_html_e( 'Subscriptions', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Package your coaching into flexible membership options and show exactly what each level includes.', 'fitwithadi' ); ?></p>
+                <a class="card__link" href="<?php echo esc_url( $subscriptions_link ); ?>"><?php esc_html_e( 'Review plans', 'fitwithadi' ); ?></a>
+            </article>
+            <article class="card card--link">
+                <h3><?php esc_html_e( 'Member Access', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Allow new members to register, submit their waiver, and access subscriber-only training in one place.', 'fitwithadi' ); ?></p>
+                <a class="card__link" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Manage sign ups', 'fitwithadi' ); ?></a>
+            </article>
+            <article class="card card--link">
+                <h3><?php esc_html_e( 'Testimonials', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Showcase transformation stories and social proof from your community to inspire future clients.', 'fitwithadi' ); ?></p>
+                <a class="card__link" href="<?php echo esc_url( $testimonials_link ); ?>"><?php esc_html_e( 'Read the stories', 'fitwithadi' ); ?></a>
+            </article>
         </div>
     </div>
 </section>
 
+<section class="section section--accent" id="pillars">
+    <div class="container pillars">
+        <div class="pillars__intro">
+            <h2><?php esc_html_e( 'The FitWithAdi method', 'fitwithadi' ); ?></h2>
+            <p><?php esc_html_e( 'Every program blends these five pillars so you can build strength, balance hormones, and keep your energy high.', 'fitwithadi' ); ?></p>
+        </div>
+        <div class="pillars__grid">
+            <article class="pillar">
+                <h3><?php esc_html_e( 'Strength foundations', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Progressive overload, proper form, and smart recovery for sustainable results.', 'fitwithadi' ); ?></p>
+            </article>
+            <article class="pillar">
+                <h3><?php esc_html_e( 'Athletic conditioning', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Dynamic intervals and mobility work that improve performance and keep workouts fun.', 'fitwithadi' ); ?></p>
+            </article>
+            <article class="pillar">
+                <h3><?php esc_html_e( 'Nutrition guidance', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Macro-friendly recipes and hydration habits to support training and recovery.', 'fitwithadi' ); ?></p>
+            </article>
+            <article class="pillar">
+                <h3><?php esc_html_e( 'Mindset & accountability', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Check-ins, progress tracking, and community wins to keep motivation high.', 'fitwithadi' ); ?></p>
+            </article>
+            <article class="pillar">
+                <h3><?php esc_html_e( 'Lifestyle integration', 'fitwithadi' ); ?></h3>
+                <p><?php esc_html_e( 'Programming that adapts to travel, busy seasons, and every stage of womanhood.', 'fitwithadi' ); ?></p>
+            </article>
+        </div>
+    </div>
+</section>
 
-<section class="section section--accent" id="cta">
-    <div class="container cta">
+<section class="section" id="cta">
+    <div class="container cta cta--front">
         <div class="cta__content">
-            <h2><?php esc_html_e( 'Ready to feel vibrant, capable, and unstoppable?', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Let’s build a training plan that fits your life. Sessions available mornings, lunch breaks, evenings, and weekends.', 'fitwithadi' ); ?></p>
+            <h2><?php esc_html_e( 'Ready to make FitWithAdi your fitness home?', 'fitwithadi' ); ?></h2>
+            <p><?php esc_html_e( 'Start your membership, share your goals, and access the resources that keep you consistent—from personalized plans to energetic group challenges.', 'fitwithadi' ); ?></p>
         </div>
-        <a class="btn btn--dark" href="#contact"><?php esc_html_e( 'Start your consultation', 'fitwithadi' ); ?></a>
-    </div>
-</section>
-
-<section class="section section--light" id="contact">
-    <div class="container contact">
-        <div class="contact__info">
-            <h2><?php esc_html_e( 'Let’s connect', 'fitwithadi' ); ?></h2>
-            <p><?php esc_html_e( 'Share your goals and schedule. Adi will reach out within 24 hours with availability and next steps.', 'fitwithadi' ); ?></p>
-            <ul class="contact__list">
-                <li><strong><?php esc_html_e( 'Call or text:', 'fitwithadi' ); ?></strong> <a href="tel:+15616010857">(561) 601-0857</a></li>
-                <li><strong><?php esc_html_e( 'Email:', 'fitwithadi' ); ?></strong> <a href="mailto:gofitwithadi@gmail.com">gofitwithadi@gmail.com</a></li>
-            </ul>
-        </div>
-        <form class="contact__form" action="mailto:gofitwithadi@gmail.com" method="post" enctype="text/plain">
-
-            <div class="form__group">
-                <label for="contact-name"><?php esc_html_e( 'Name', 'fitwithadi' ); ?></label>
-                <input type="text" id="contact-name" name="name" required>
-            </div>
-            <div class="form__group">
-                <label for="contact-email"><?php esc_html_e( 'Email', 'fitwithadi' ); ?></label>
-                <input type="email" id="contact-email" name="email" required>
-            </div>
-            <div class="form__group">
-                <label for="contact-phone"><?php esc_html_e( 'Phone number', 'fitwithadi' ); ?></label>
-                <input type="tel" id="contact-phone" name="phone" required>
-            </div>
-            <div class="form__group">
-                <label for="contact-preferences"><?php esc_html_e( 'Preferred training style', 'fitwithadi' ); ?></label>
-                <select id="contact-preferences" name="preference">
-                    <option value="studio"><?php esc_html_e( 'Private studio', 'fitwithadi' ); ?></option>
-                    <option value="home"><?php esc_html_e( 'In-home', 'fitwithadi' ); ?></option>
-                    <option value="group"><?php esc_html_e( 'Group sessions', 'fitwithadi' ); ?></option>
-                    <option value="hybrid"><?php esc_html_e( 'Hybrid mix', 'fitwithadi' ); ?></option>
-                    <option value="remote"><?php esc_html_e( 'Remote/Online', 'fitwithadi' ); ?></option>
-                </select>
-            </div>
-            <div class="form__group">
-                <label for="contact-communication"><?php esc_html_e( 'Preferred way to connect', 'fitwithadi' ); ?></label>
-                <select id="contact-communication" name="communication">
-                    <option value="call"><?php esc_html_e( 'Call', 'fitwithadi' ); ?></option>
-                    <option value="text"><?php esc_html_e( 'Text', 'fitwithadi' ); ?></option>
-                    <option value="email"><?php esc_html_e( 'Email', 'fitwithadi' ); ?></option>
-                </select>
-            </div>
-            <div class="form__group">
-                <label for="contact-message"><?php esc_html_e( 'Tell Adi about your goals', 'fitwithadi' ); ?></label>
-                <textarea id="contact-message" name="message" rows="4" required></textarea>
-            </div>
-            <button class="btn btn--dark" type="submit"><?php esc_html_e( 'Send message', 'fitwithadi' ); ?></button>
-            <p class="form__footnote"><?php esc_html_e( 'Prefer DM? Find Adi on Instagram @fitwithadi.', 'fitwithadi' ); ?></p>
-        </form>
+        <a class="btn btn--dark" href="<?php echo esc_url( $member_access_link ); ?>"><?php esc_html_e( 'Register & sign the waiver', 'fitwithadi' ); ?></a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- redesign the front page to introduce Adi, highlight key site sections, and link into the new multi-page experience
- add dedicated templates for the content hub, subscription plans, member registration/waiver workflow, and testimonials library backed by a custom post type
- refresh global styling and branding with a new SVG logo, extended pink/red palette components, and admin tools for managing submitted waivers

## Testing
- php -l wp-content/themes/fitwithadi/header.php
- php -l wp-content/themes/fitwithadi/footer.php
- php -l wp-content/themes/fitwithadi/functions.php
- php -l wp-content/themes/fitwithadi/template-parts/content-home.php
- php -l wp-content/themes/fitwithadi/page-content-hub.php
- php -l wp-content/themes/fitwithadi/page-subscriptions.php
- php -l wp-content/themes/fitwithadi/page-member-access.php
- php -l wp-content/themes/fitwithadi/page-testimonials.php

------
https://chatgpt.com/codex/tasks/task_e_68d570511000833295d1f97b58214eaf